### PR TITLE
Add usage guidelines for Zarr logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Zarr Logo
 
+### Usage of the Zarr Logo
+
+The Zarr logo is a registered trademark, and its use must comply with the guidelines set forth by **NumFOCUS**, the organization that owns the trademark. To ensure consistent and appropriate use, please adhere to the [NumFOCUS Trademark Guidelines](https://numfocus.org/trademark-guidelines) when using the Zarr logo in any materials, branding, or promotions. Unauthorized or improper use may lead to trademark infringement, so please take care to review these guidelines before incorporating the logo into your work.
+
+If you have any questions or would like to request permission for specific use cases, please contact [NumFOCUS](https://numfocus.org/).
+
 ## SVGs
 
 ### Horizontal
@@ -27,7 +33,7 @@ This is the color gradient that is used in the logo.
 PNGs are available under the release builds. For the latest versions,
 please see https://github.com/zarr-developers/zarr-logo/releases/latest
 
-## Uses
+## Uses in the wild
 
 Locations that are using these logos:
 * zarr-python [settings](https://github.com/zarr-developers/zarr-python/settings) and [README](https://github.com/zarr-developers/zarr-python/blob/master/README.md)


### PR DESCRIPTION
Added usage guidelines for the Zarr logo, including trademark information and a link to NumFOCUS guidelines.

cc: @maxrjones @rabernat @normanrz 

see: #4 #5